### PR TITLE
Bugfix/fix insert point display bug

### DIFF
--- a/nodefinderc.c
+++ b/nodefinderc.c
@@ -46,6 +46,18 @@ void printcali(struct Calibration cali)
 // Utils functions
 // =======================================================
 
+void gen_blank_str(char **blank_str, size_t whitespace_num)
+{
+    int i;
+    static char temp_str[MAX_WHITESPACES_NUM];
+
+    *blank_str = temp_str;
+
+    for (i=0; i<whitespace_num; i++)
+        temp_str[i] = ' ';
+    temp_str[i] = '\0';
+}
+
 char* make_str_clean(char* input)
 {
     int i,j;
@@ -267,11 +279,14 @@ int get_index_of_tmrca(const char *treestr, const char *name_a, const char *name
     int insertion_list_a[MAX_INDEX_LIST_NUM], insertion_list_b[MAX_INDEX_LIST_NUM];
     int list_num_a, list_num_b;
     size_t name_a_index, name_b_index;
+    size_t treelen;
     int shorter_list_num;
     int i;
     int index_of_tmrca;
+    char *blank_str;
 
     index_of_tmrca = -1;
+    treelen = strlen(treestr);
 
     name_a_index = get_index_of_substring(treestr, name_a);
     name_b_index = get_index_of_substring(treestr, name_b);
@@ -309,11 +324,37 @@ int get_index_of_tmrca(const char *treestr, const char *name_a, const char *name
     }
 
     printf("[Common]:  %d\n", index_of_tmrca);
-    printf("\n[Insert]:  %s%s\n",
-        sliced_string(treestr, index_of_tmrca-20, index_of_tmrca),
-        sliced_string(treestr, index_of_tmrca, index_of_tmrca+20));
-    printf("[Insert]:                   ->||<-                  \n");
-    printf("[Insert]:                 Insert Here               \n");
+
+    if ((index_of_tmrca < CALI_DISPLAY_HALF_WIDTH) && \
+            (treelen - index_of_tmrca >= CALI_DISPLAY_HALF_WIDTH)){
+        gen_blank_str(&blank_str, CALI_DISPLAY_HALF_WIDTH - index_of_tmrca);
+        printf("%s\n", blank_str);
+        printf("\n[Insert]:  %s%s%s\n",
+               blank_str,
+               sliced_string(treestr, 0, index_of_tmrca),
+               sliced_string(treestr,
+                             index_of_tmrca,
+                             index_of_tmrca + CALI_DISPLAY_HALF_WIDTH));
+    } else if (index_of_tmrca >= CALI_DISPLAY_HALF_WIDTH && \
+            treelen - index_of_tmrca < CALI_DISPLAY_HALF_WIDTH) {
+        printf("\n[Insert]:  %s\n",
+               sliced_string(treestr, index_of_tmrca-CALI_DISPLAY_HALF_WIDTH, treelen));
+    } else if (index_of_tmrca < CALI_DISPLAY_HALF_WIDTH && \
+            treelen - index_of_tmrca < CALI_DISPLAY_HALF_WIDTH) {
+        gen_blank_str(&blank_str, CALI_DISPLAY_HALF_WIDTH - index_of_tmrca);
+        printf("\n[Insert]:  %s%s\n",
+               blank_str,
+               sliced_string(treestr, 0, treelen));
+    } else {
+        printf("\n[Insert]:  %s\n",
+               sliced_string(treestr,
+                             index_of_tmrca-CALI_DISPLAY_HALF_WIDTH,
+                             index_of_tmrca+CALI_DISPLAY_HALF_WIDTH));
+    }
+    gen_blank_str(&blank_str, CALI_DISPLAY_HALF_WIDTH - 3);
+    printf("[Insert]:  %s->||<-\n", blank_str);
+    gen_blank_str(&blank_str, CALI_DISPLAY_HALF_WIDTH - 5);
+    printf("[Insert]:  %sInsert Here\n", blank_str);
 
     // printf("Index of tMRCA: %d\n", index_of_tmrca);
     return index_of_tmrca;
@@ -652,6 +693,7 @@ int main(int argc, char **argv)
 
     /* Do calibrations */
     clean_str = multi_cali(clean_str, valid_line_num, calis);
+    printf("\n%s\n", clean_str);
 
     /* Save output to file */
     write_str_to_file(outfile_value, clean_str);

--- a/nodefinderc.h
+++ b/nodefinderc.h
@@ -5,13 +5,43 @@
 #include <string.h>
 #include <unistd.h>
 
-#define NODEFINDERC_VERSION "1.1.6"
-#define MAX_INDEX_LIST_NUM 200
-#define MULTIPLE_OF_BUFSIZE 2
+/* ===================================================================== */
+/* Options you may want to change*/
+/* ===================================================================== */
+/* The maximum line numbers for calibration configs (default: 500) */
 #define MAX_CONFIG_LINE_LEN 500
-#define COMMENT_SYMBOL '#'
-#define MAX_WHITESPACES_NUM 200
+
+/* The length of insertion point display.
+ * For example, default value (20):
+ *           |      -> 20 <-     ||     -> 20 <-     |
+ * [Insert]:  b,c)>0.05<0.07,(d,e)))>0.1<0.2,(f,g))>0.
+ * [Insert]:                   ->||<-
+ * [Insert]:                 Insert Here
+ */
 #define CALI_DISPLAY_HALF_WIDTH 20
+
+/* The max size of ancestor insertion point list. (default: 400) */
+#define MAX_INDEX_LIST_NUM 400
+
+/* ===================================================================== */
+/* Options generally don't need to be changed*/
+/* ===================================================================== */
+
+/* NodeFinder version */
+#define NODEFINDERC_VERSION "1.1.6"
+
+/* Symbol used for comment lines. Lines starts with this will be ignored.
+ * (defualt: '#')*/
+#define COMMENT_SYMBOL '#'
+
+/* The max whitespaces number used in gen_blank_str() function to
+ * get a string consists of whitespaces only. (default: 200) */
+#define MAX_WHITESPACES_NUM 200
+
+/* The buffer multiple size used by add_cali() and modify_exists_cali() fucntion
+ * for adding calibration string. (default: 2) */
+#define MULTIPLE_OF_BUFSIZE 2
+
 
 const char *BAR = "=======================================================================\n";
 const char *THIN_BAR = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";

--- a/nodefinderc.h
+++ b/nodefinderc.h
@@ -10,6 +10,8 @@
 #define MULTIPLE_OF_BUFSIZE 2
 #define MAX_CONFIG_LINE_LEN 500
 #define COMMENT_SYMBOL '#'
+#define MAX_WHITESPACES_NUM 200
+#define CALI_DISPLAY_HALF_WIDTH 20
 
 const char *BAR = "=======================================================================\n";
 const char *THIN_BAR = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
@@ -31,6 +33,7 @@ void printcali(struct Calibration cali);
 
 
 // Utils functions
+void gen_blank_str(char **blank_str, size_t whitespace_num);
 char* make_str_clean(char* input);
 char *stripchar(char *str, const char c);
 size_t countchar(const char *s, const char c);


### PR DESCRIPTION
For a tree like this:

```
((a ,((b, c), (d, e))), (f, g));
```

Given calibration configs:

```
c, b, >0.05<0.07
a, e, >0.1<0.2
c, f, >0.3<0.5
d, e, $1
a, #1
```

Output Newick tree will be:

```
((a#1, ((b, c)>0.05<0.07, (d, e)$1))>0.1<0.2, (f, g))>0.3<0.5;
```

Log will be:

```
[1]:  c, b, >0.05<0.07
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   c
[Name B]:   b
[ Info ]:   >0.05<0.07
[Common]:   10

[Insert]:             ((a,((b,c),(d,e))),(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[2]:  a, e, >0.1<0.2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   a
[Name B]:   e
[ Info ]:   >0.1<0.2
[Common]:   28

[Insert]:   c)>0.05<0.07,(d,e))),(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[3]:  c, f, >0.3<0.5
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   c
[Name B]:   f
[ Info ]:   >0.3<0.5
[Common]:   43

[Insert]:   ,e)))>0.1<0.2,(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[4]:  d, e, $1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   d
[Name B]:   e
[ Info ]:   $1
[Common]:   26

[Insert]:   b,c)>0.05<0.07,(d,e)))>0.1<0.2,(f,g))>0.
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


[5]:  a, #1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ Name ]:   a
[ Info ]:   #1
[Common]:   3

[Insert]:                    ((a,((b,c)>0.05<0.07,(d
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Before fixed this bug, insertion point information will not be displayed correctly due to the insert_point<20, or tree_len - insert_point < 20.

Take calibration [1] as example (incorrect display, missing leading blanks):

```
[1]:  c, b, >0.05<0.07
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Name A]:   c
[Name B]:   b
[ Info ]:   >0.05<0.07
[Common]:   10

[Insert]:   ((a,((b,c),(d,e))),(f,g));
[Insert]:                    ->||<-                 
[Insert]:                  Insert Here              
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
